### PR TITLE
(WIP) Windows installer should wait on msiexec

### DIFF
--- a/lib/pe_build/cap/run_install/windows.rb
+++ b/lib/pe_build/cap/run_install/windows.rb
@@ -23,7 +23,7 @@ class PEBuild::Cap::RunInstall::Windows
     installer = File.join(root, archive.to_s).gsub('/', '\\')
 
     cmd = []
-    cmd << 'msiexec' << '/qn' << '/i' << installer
+    cmd << 'start' << '/wait' << 'msiexec' << '/qn' << '/i' << installer
 
     cmd << "PUPPET_MASTER_SERVER=#{config.master}"
     cmd << "PUPPET_AGENT_CERTNAME=#{machine.name}"


### PR DESCRIPTION
MSIEXEC is a non-blocking call, to to ensure it completes, it should
have start /wait in front of the call.


I'm also working on specs for this, but it's been a fun process. :/