### PR TITLE
Patch1 support split stack

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,7 @@ overridden at this point.
 
   * `role`
     * Description: The role of the Puppet Enterprise install.
-    * Options: `:agent`, `:master`
+    * Options: `:agent`, `:master`, `:camom`, `:puppetdb`, `:console`, `:cmaster`
     * Default: `:agent`
   * `verbose`
     * Description: Whether or not to show the verbose output of the Puppet

--- a/lib/pe_build/config/pe_bootstrap.rb
+++ b/lib/pe_build/config/pe_bootstrap.rb
@@ -23,7 +23,7 @@ class PEBuild::Config::PEBootstrap < PEBuild::Config::Global
   attr_accessor :role
 
   # @api private
-  VALID_ROLES = [:agent, :master]
+  VALID_ROLES = [:agent, :master, :camom, :puppetdb, :console, :cmaster]
 
   # @!attribute relocate_manifests
   #   @return [TrueClass, FalseClass] if the puppet master should use manifests

--- a/lib/pe_build/config/pe_bootstrap.rb
+++ b/lib/pe_build/config/pe_bootstrap.rb
@@ -7,6 +7,21 @@ class PEBuild::Config::PEBootstrap < PEBuild::Config::Global
   #   @since 0.1.0
   attr_accessor :master
 
+  # @!attribute camom
+  #   @return [String] The DNS hostname of the Puppet ca for this node.
+  #   @since 0.1.0
+  attr_accessor :camom
+  
+  # @!attribute puppetdb
+  #   @return [String] The DNS hostname of the puppetdb server for this node.
+  #   @since 0.1.0
+  attr_accessor :puppetdb
+
+  # @!attribute console
+  #   @return [String] The DNS hostname of the console server for this node.
+  #   @since 0.1.0
+  attr_accessor :console
+
   # @!attribute answer_file
   #   @return [String] The path to a user specified answer_file file (Optional)
   #   @since 0.1.0
@@ -52,6 +67,9 @@ class PEBuild::Config::PEBootstrap < PEBuild::Config::Global
     @role        = UNSET_VALUE
     @verbose     = UNSET_VALUE
     @master      = UNSET_VALUE
+    @camom       = UNSET_VALUE
+    @puppetdb    = UNSET_VALUE
+    @console      = UNSET_VALUE
     @answer_file = UNSET_VALUE
 
     @relocate_manifests = UNSET_VALUE
@@ -70,6 +88,9 @@ class PEBuild::Config::PEBootstrap < PEBuild::Config::Global
     set_default :@role,        :agent
     set_default :@verbose,     true
     set_default :@master,      'master'
+    set_default :@camom,       'camom'
+    set_default :@puppetdb,    'puppetdb'
+    set_default :@console,     'console'
     set_default :@answer_file, nil
     set_default :@autosign,    (@role == :master)
 

--- a/lib/pe_build/config_builder/pe_bootstrap.rb
+++ b/lib/pe_build/config_builder/pe_bootstrap.rb
@@ -15,6 +15,18 @@ class PEBuild::ConfigBuilder::PEBootstrap < ::PEBuild::ConfigBuilder::Global
   #   @return [String] The address of the puppet master.
   def_model_attribute :master
 
+  # @!attribute [rw] camom
+  #   @return [String] The address of the puppet ca.
+  def_model_attribute :camom
+
+  # @!attribute [rw] puppetdb
+  #   @return [String] The address of the puppetdb server.
+  def_model_attribute :puppetdb
+
+  # @!attribute [rw] console
+  #   @return [String] The address of the console server.
+  def_model_attribute :console
+
   # @!attribute [rw] answer_file
   #   @return [String] The location of alternate answer file for PE
   #     installation. Values can be paths relative to the Vagrantfile's project
@@ -54,6 +66,9 @@ class PEBuild::ConfigBuilder::PEBootstrap < ::PEBuild::ConfigBuilder::Global
         pe.role               = attr(:role)               if attr(:role)
         pe.verbose            = attr(:verbose)            if attr(:verbose)
         pe.master             = attr(:master)             if attr(:master)
+	pe.camom              = attr(:camom)              if attr(:camom)
+	pe.puppetdb           = attr(:puppetdb)           if attr(:puppetdb)
+	pe.console            = attr(:console)            if attr(:console)
         pe.answer_file        = attr(:answer_file)        if attr(:answer_file)
         pe.relocate_manifests = attr(:relocate_manifests) if attr(:relocate_manifests)
         pe.autosign           = attr(:autosign)           if attr(:autosign)

--- a/lib/pe_build/release/3_8.rb
+++ b/lib/pe_build/release/3_8.rb
@@ -52,6 +52,10 @@ module PEBuild::Release
     #  add_release :cumulus, 'see forge module'
 
     set_answer_file :master, File.join(PEBuild.template_dir, 'answers', 'master-3.x.txt.erb')
+    set_answer_file :camom, File.join(PEBuild.template_dir, 'answers', 'camom-3.8.txt.erb')
+    set_answer_file :puppetdb, File.join(PEBuild.template_dir, 'answers', 'puppetdb-3.8.txt.erb')
+    set_answer_file :console, File.join(PEBuild.template_dir, 'answers', 'console-3.8.txt.erb')
+    set_answer_file :cmaster, File.join(PEBuild.template_dir, 'answers', 'cmaster-3.8.txt.erb')
     set_answer_file :agent,  File.join(PEBuild.template_dir, 'answers', 'agent-3.x.txt.erb')
   end
 

--- a/templates/answers/camom-3.8.txt.erb
+++ b/templates/answers/camom-3.8.txt.erb
@@ -1,0 +1,21 @@
+q_all_in_one_install=n
+q_enable_future_parser=n
+q_fail_on_unsuccessful_master_lookup=y
+q_install=y
+q_pe_check_for_updates=y
+q_puppet_cloud_install=n
+q_puppet_enterpriseconsole_install=n
+q_puppetagent_certname=<%= machine_hostname %>
+q_puppetagent_install=y
+q_puppetagent_server=<%= machine_hostname %>
+q_puppetdb_hostname=<%= @config.puppetdb %>
+q_puppetdb_install=n
+q_puppetdb_port=8081
+q_puppetmaster_certname=<%= machine_hostname %>
+q_puppetmaster_dnsaltnames=puppet,camom
+q_puppetmaster_enterpriseconsole_hostname=<%= @config.console %>
+q_puppetmaster_enterpriseconsole_port=443
+q_puppetmaster_install=y
+q_skip_backup=y
+q_skip_master_verification=n
+q_vendor_packages_install=y

--- a/templates/answers/console-3.8.txt.erb
+++ b/templates/answers/console-3.8.txt.erb
@@ -1,0 +1,38 @@
+q_activity_database_name=pe-activity
+q_activity_database_password=686Pg6RW2LYHRcrNpmtgVg
+q_activity_database_user=pe-activity
+q_classifier_database_name=pe-classifier
+q_classifier_database_password=bZ9Pd1x4Slckd_LN4_a9Ig
+q_classifier_database_user=pe-classifier
+q_database_host=<%= @config.puppetdb %>
+q_database_port=5432
+q_enable_future_parser=n
+q_fail_on_unsuccessful_master_lookup=y
+q_install=y
+q_pe_database=y
+q_public_hostname=<%= machine_hostname %>
+q_puppet_cloud_install=n
+q_puppet_enterpriseconsole_auth_password=puppetlabs
+q_puppet_enterpriseconsole_database_name=console
+q_puppet_enterpriseconsole_database_password=03zLm-mmN3TtaUtG3ygbgQ
+q_puppet_enterpriseconsole_database_user=console
+q_puppet_enterpriseconsole_httpd_port=443
+q_puppet_enterpriseconsole_install=y
+q_puppet_enterpriseconsole_master_hostname=<%= @config.camom %>
+q_puppetagent_certname=<%= machine_hostname %>
+q_puppetagent_install=y
+q_puppetagent_server=camomhostname
+q_puppetdb_database_name=pe-puppetdb
+q_puppetdb_database_password=-ABkMDmG1o29plcC8vZHSA
+q_puppetdb_database_user=pe-puppetdb
+q_puppetdb_hostname=<%= @config.puppetdb %>
+q_puppetdb_install=n
+q_puppetdb_port=8081
+q_puppetmaster_certname=<%= @config.camom %>
+q_puppetmaster_install=n
+q_rbac_database_name=pe-rbac
+q_rbac_database_password=W3tGPbK50vmQq8vhVGHzYw
+q_rbac_database_user=pe-rbac
+q_skip_backup=y
+q_skip_master_verification=n
+q_vendor_packages_install=y

--- a/templates/answers/console-3.8.txt.erb
+++ b/templates/answers/console-3.8.txt.erb
@@ -21,7 +21,7 @@ q_puppet_enterpriseconsole_install=y
 q_puppet_enterpriseconsole_master_hostname=<%= @config.camom %>
 q_puppetagent_certname=<%= machine_hostname %>
 q_puppetagent_install=y
-q_puppetagent_server=camomhostname
+q_puppetagent_server=<%= @config.camom %>
 q_puppetdb_database_name=pe-puppetdb
 q_puppetdb_database_password=-ABkMDmG1o29plcC8vZHSA
 q_puppetdb_database_user=pe-puppetdb

--- a/templates/answers/puppetdb-3.8.txt.erb
+++ b/templates/answers/puppetdb-3.8.txt.erb
@@ -1,0 +1,37 @@
+ctivity_database_name=pe-activity
+q_activity_database_password=686Pg6RW2LYHRcrNpmtgVg
+q_activity_database_user=pe-activity
+q_classifier_database_name=pe-classifier
+q_classifier_database_password=bZ9Pd1x4Slckd_LN4_a9Ig
+q_classifier_database_user=pe-classifier
+q_database_host=<%= machine_hostname %>
+q_database_install=y
+q_database_port=5432
+q_database_root_password=vY5dloovecdXXdHEb7YLOg
+q_database_root_user=root
+q_fail_on_unsuccessful_master_lookup=y
+q_install=y
+q_pe_database=y
+q_puppet_cloud_install=n
+q_puppet_enterpriseconsole_database_name=console
+q_puppet_enterpriseconsole_database_password=03zLm-mmN3TtaUtG3ygbgQ
+q_puppet_enterpriseconsole_database_user=console
+q_puppet_enterpriseconsole_install=n
+q_puppetagent_certname=<%= machine_hostname %>
+q_puppetagent_install=y
+q_puppetagent_server=<%= @config.camom %>
+q_puppetdb_database_name=pe-puppetdb
+q_puppetdb_database_password=-ABkMDmG1o29plcC8vZHSA
+q_puppetdb_database_user=pe-puppetdb
+q_puppetdb_hostname=<%= machine_hostname %>
+q_puppetdb_install=y
+q_puppetdb_plaintext_port=8080
+q_puppetdb_port=8081
+q_puppetmaster_certname=<%= @config.master %>
+q_puppetmaster_install=n
+q_rbac_database_name=pe-rbac
+q_rbac_database_password=W3tGPbK50vmQq8vhVGHzYw
+q_rbac_database_user=pe-rbac
+q_skip_backup=y
+q_skip_master_verification=n
+q_vendor_packages_install=y


### PR DESCRIPTION
This patch adds optional roles for a split installation. (camom, puppetdb, console). Likely needs some additional love.