### PR TITLE
Use proper paths for 2015.2

### DIFF
--- a/lib/pe_build/provisioner/pe_bootstrap/post_install.rb
+++ b/lib/pe_build/provisioner/pe_bootstrap/post_install.rb
@@ -29,7 +29,7 @@ class PEBuild::Provisioner::PEBootstrap::PostInstall
       manifest = resources.join("\n\n")
       write_manifest(manifest)
 
-      if PEBuild::Util::VersionString.compare(@config.version, '4.0.0') < 0 then
+      if PEBuild::Util::VersionString.compare(@config.version, '2015.2.0') < 0 then
         puppet_apply  = "/opt/puppet/bin/puppet apply"
       else
         puppet_apply  = "/opt/puppetlabs/bin/puppet apply"


### PR DESCRIPTION
Previous to this commit, the post_intall process used a conditional to 
determine whether to use /opt/puppet/bin/puppet or
/opt/puppetlabs/puppet/bin/puppet for the puppet executable. The conditional
tested for PE version 4.0.0.  However, the new versioning scheme follows a
year.minor.bug scheme.  This commit uses the correct 2015.2 instead of 4.0.0