### PR TITLE
Fixes to pave way for 2015.2 support

### DIFF
--- a/lib/pe_build/cap/run_install/posix.rb
+++ b/lib/pe_build/cap/run_install/posix.rb
@@ -31,7 +31,7 @@ class PEBuild::Cap::RunInstall::POSIX
 
     if machine.communicate.test('which at')
       machine.ui.info I18n.t('pebuild.cap.run_install.scheduling_run')
-      machine.communicate.sudo("echo '/opt/puppet/bin/puppet agent -t --waitforcert 10' | at now '+ 1min'")
+      machine.communicate.sudo("echo 'PATH=/opt/puppet/bin:/opt/puppetlabs/puppet/bin:$PATH puppet agent -t --waitforcert 10' | at now '+ 1min'")
     end
   end
 end

--- a/templates/answers/master-3.x.txt.erb
+++ b/templates/answers/master-3.x.txt.erb
@@ -43,3 +43,4 @@ q_run_updtvpkg=n
 q_vendor_packages_install=y
 q_verify_packages=y
 q_enable_future_parser=n
+q_pe_check_for_updates=n


### PR DESCRIPTION
1. Turns off check for updates: https://docs.puppetlabs.com/pe/latest/puppet_config.html#disabling-update-checking

2. Uses PATH variable so run puppet code works same across 3.x and PE based on Puppet 4.x