### PR TITLE
Add support for 2015.2.x

### DIFF
--- a/lib/pe_build/release.rb
+++ b/lib/pe_build/release.rb
@@ -38,6 +38,6 @@ module PEBuild
     require 'pe_build/release/3_7'
     require 'pe_build/release/3_8'
 
-    LATEST_VERSION = '3.8.2'
+    LATEST_VERSION = '2015.2.1'
   end
 end

--- a/lib/pe_build/release/2015_2.rb
+++ b/lib/pe_build/release/2015_2.rb
@@ -1,0 +1,61 @@
+require 'pe_build/release'
+
+module PEBuild::Release
+
+  twentyfifteen_two_x = newrelease do
+
+    add_release :debian, '6'
+    add_release :debian, '7'
+
+    add_release :el, '4'
+    add_release :el, '5'
+    add_release :el, '6'
+    add_release :el, '7'
+
+    add_release :sles, '10'
+    add_release :sles, '11'
+    add_release :sles, '12'
+
+    add_release :solaris, '10'
+    add_release :solaris, '11'
+
+    add_release :ubuntu, '10.04'
+    add_release :ubuntu, '12.04'
+    add_release :ubuntu, '14.04'
+
+    add_release :windows, '2003'
+    add_release :windows, '2003R2'
+    add_release :windows, '2008'
+    add_release :windows, '2008R2'
+    add_release :windows, '7'
+    add_release :windows, '2012'
+    add_release :windows, '2012R2'
+    add_release :windows, '8'
+    add_release :windows, '8.1'
+
+    # TODO: PE 3.3 and newer have support for OS X, but we weed to add some
+    # capabilities to make this functional.
+    #
+    # add_release :osx, '10.9'
+
+    # PE 3.x has support for AIX, but as of 2013-08-12 Vagrant has nothing
+    # remotely resembling support for AIX WPARs or LPARs. Since it's meaningless
+    # to try to add support for AIX, we just leave this commented out.
+    #
+    # add_release :aix, '5.3'
+    # add_release :aix, '6.1'
+    # add_release :aix, '7.1'
+
+    # Starting with PE 3.7, Network Device agents are also supported
+    #
+    #  add_release :arista,  'see forge module'
+    #  add_release :cumulus, 'see forge module'
+
+    set_answer_file :master, File.join(PEBuild.template_dir, 'answers', 'master-2015.x.txt.erb')
+    set_answer_file :agent,  File.join(PEBuild.template_dir, 'answers', 'agent-2015.x.txt.erb')
+  end
+
+  @releases['2015.2.0'] = twentyfifteen_two_x
+  @releases['2015.2.1'] = twentyfifteen_two_x
+end
+

--- a/templates/answers/agent-2015.x.txt.erb
+++ b/templates/answers/agent-2015.x.txt.erb
@@ -1,0 +1,16 @@
+q_fail_on_unsuccessful_master_lookup=y
+q_install=y
+q_puppet_cloud_install=n
+q_puppet_enterpriseconsole_install=n
+q_puppet_symlinks_install=y
+q_puppetagent_certname=<%= machine_hostname %>
+q_puppetagent_install=y
+q_puppetagent_server=<%= @config.master %>
+q_puppetca_install=n
+q_puppetdb_hostname=
+q_puppetdb_install=n
+q_puppetdb_port=
+q_puppetmaster_install=n
+q_vendor_packages_install=y
+q_continue_or_reenter_master_hostname=c
+q_verify_packages=y

--- a/templates/answers/master-2015.x.txt.erb
+++ b/templates/answers/master-2015.x.txt.erb
@@ -1,0 +1,45 @@
+q_all_in_one_install=y
+q_database_host=<%= machine_hostname %>
+q_database_install=y
+q_database_port=5432
+q_database_root_password=wcAdzLoHz6Vpzp6TJPLT
+q_database_root_user=pe-postgres
+q_install=y
+q_pe_database=y
+q_puppet_cloud_install=y
+q_puppet_enterpriseconsole_auth_database_name=console_auth
+q_puppet_enterpriseconsole_auth_database_password=y33blQzfW9ZiCSpSztlN
+q_puppet_enterpriseconsole_auth_database_user=console_auth
+q_puppet_enterpriseconsole_auth_password=puppetlabs
+q_puppet_enterpriseconsole_auth_user_email=admin@puppetlabs.com
+q_puppet_enterpriseconsole_database_name=console
+q_puppet_enterpriseconsole_database_password=aX5nCiKbkjKEBVzW0tCx
+q_puppet_enterpriseconsole_database_user=console
+q_puppet_enterpriseconsole_httpd_port=443
+q_puppet_enterpriseconsole_install=y
+q_puppet_enterpriseconsole_master_hostname=<%= machine_hostname %>
+q_puppet_enterpriseconsole_smtp_host=localhost
+q_puppet_enterpriseconsole_smtp_password=
+q_puppet_enterpriseconsole_smtp_port=25
+q_puppet_enterpriseconsole_smtp_use_tls=n
+q_puppet_enterpriseconsole_smtp_user_auth=n
+q_puppet_enterpriseconsole_smtp_username=
+q_puppet_symlinks_install=y
+q_puppetagent_certname=<%= machine_hostname %>
+q_puppetagent_install=y
+q_puppetagent_server=<%= machine_hostname %>
+q_puppetdb_database_name=pe-puppetdb
+q_puppetdb_database_password=MCPaKB0ERo0FlAN60sny
+q_puppetdb_database_user=pe-puppetdb
+q_puppetdb_hostname=<%= machine_hostname %>
+q_puppetdb_install=y
+q_puppetdb_port=8081
+q_puppetmaster_certname=<%= machine_hostname %>
+q_puppetmaster_dnsaltnames=<%= machine_hostname %>,puppet
+q_puppetmaster_enterpriseconsole_port=443
+q_puppetmaster_install=y
+q_run_updtvpkg=n
+q_vendor_packages_install=y
+q_verify_packages=y
+q_enable_future_parser=n
+q_pe_check_for_updates=n


### PR DESCRIPTION
Mostly this is just extending the skeleton but functionally it updates a master answers file that causes problems installing PE for 2015.2.1.