### PR TITLE
Add certname option to pe_agent provisioner

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,6 +120,11 @@ with the global `config.pe_build` settings.
     * Options: A version string, `x.y.z[-optional-stuff]`, or the string
       `'current'`.
     * Default: `'current'`.
+  * `certname`
+    * Description: How to determine which certname to use for the agent.
+      **NOTE:** This option only works on POSIX agents for now.
+    * Options: `vm_name`, `hostname`, or `fqdn`
+    * Default: `vm_name`
 
 
 Commands

--- a/lib/pe_build/config/pe_agent.rb
+++ b/lib/pe_build/config/pe_agent.rb
@@ -37,12 +37,18 @@ class PEBuild::Config::PEAgent < Vagrant.plugin('2', :config)
   #   `current`. Defaults to `current`.
   attr_accessor :version
 
+  # @!attribute certname
+  #   @return [String] What to use as the certname. May be either fqdn
+  #   hostname, or vm_name. The default is vm_name
+  attr_accessor :certname
+
   def initialize
     @autosign      = UNSET_VALUE
     @autopurge     = UNSET_VALUE
     @master        = UNSET_VALUE
     @master_vm     = UNSET_VALUE
     @version       = UNSET_VALUE
+    @certname      = UNSET_VALUE
   end
 
   def finalize!
@@ -51,6 +57,7 @@ class PEBuild::Config::PEAgent < Vagrant.plugin('2', :config)
     @autosign      = (not @master_vm.nil?) if @autosign  == UNSET_VALUE
     @autopurge     = (not @master_vm.nil?) if @autopurge == UNSET_VALUE
     @version       = 'current' if @version == UNSET_VALUE
+    @certname      = 'vm_name' if @certname = UNSET_VALUE
   end
 
   def validate(machine)

--- a/lib/pe_build/config_builder/pe_agent.rb
+++ b/lib/pe_build/config_builder/pe_agent.rb
@@ -27,6 +27,10 @@ class PEBuild::ConfigBuilder::PEAgent < ::ConfigBuilder::Model::Base
   #   string of the form `x.y.x[-optional-arbitrary-stuff]` or the string
   #   `current`. Defaults to `current`.
   def_model_attribute :version
+  # @!attribute certname
+  #   @return [String] What to use as the certname. May be either fqdn,
+  #   hostname, or vm_name. The default is vm_name
+  def_model_attribute :certname
 
   def to_proc
     Proc.new do |vm_config|
@@ -36,6 +40,7 @@ class PEBuild::ConfigBuilder::PEAgent < ::ConfigBuilder::Model::Base
         with_attr(:master)       {|val| config.master       = val }
         with_attr(:master_vm)    {|val| config.master_vm    = val }
         with_attr(:version)      {|val| config.version      = val }
+        with_attr(:certname)     {|val| config.certname     = val }
       end
     end
   end

--- a/lib/pe_build/provisioner/pe_agent.rb
+++ b/lib/pe_build/provisioner/pe_agent.rb
@@ -139,6 +139,18 @@ module PEBuild
       def provision_posix_agent
         shell_config = Vagrant.plugin('2').manager.provisioner_configs[:shell].new
         shell_config.privileged = true
+
+        certname_option = case config.certname
+                          when 'hostname'
+                            "agent:certname=#{machine.config.vm.hostname}"
+                          when 'fqdn'
+                            #The installer script already defaults to FQDN
+                            #Just let it do its thing
+                            ''
+                          when 'vm_name'
+                            "agent:certname=#{machine.name}"
+                          end
+
         # Installation is split into to components running under set -e so that
         # failures are detected. The curl command uses `sS` so that download
         # progress is silenced, but error messages are still printed.
@@ -149,7 +161,7 @@ module PEBuild
         shell_config.inline = <<-EOS
 set -e
 curl -ksS -tlsv1 https://#{config.master}:8140/packages/current/install.bash -o pe_frictionless_installer.sh
-bash pe_frictionless_installer.sh
+bash pe_frictionless_installer.sh #{certname_option}
         EOS
         shell_config.finalize!
 


### PR DESCRIPTION
Previous to this commit, the frictionless agent installer used by the
pe_agent provisioniner defaulted to the FQDN of the VM.  This can cause
inconsistent VM certnames based on what network the user is on.

This commit introduces a new role config parameter called 'certname'
that accepts three possible values:

* hostname - uses the value of host's hostname setting in Vagrant
* vm_name  - uses the VM's name as set in Vagrant
* fqdn     - uses the host's fqdn