### PR TITLE
Add fallback to master_vm if the hostname is not set on master_vm

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -110,7 +110,7 @@ with the global `config.pe_build` settings.
     * Description: The hostname or fqdn of the puppet master. Must be specified
       if `master_vm` is not set.
     * Default: `nil`. Defaults to `vm.hostname` of the Puppet Master if
-      `master_vm` is set.
+      `master_vm` is set and `master_vm` if `vm.hostname` is not set.
   * `version`
     * Description: The version number of the PE Agent to install. **NOTE:**
       this setting is currently used only for Windows agents. POSIX agents will

--- a/lib/pe_build/provisioner/pe_agent.rb
+++ b/lib/pe_build/provisioner/pe_agent.rb
@@ -57,7 +57,7 @@ module PEBuild
 
           unless vm_def.nil?
             @master_vm       = machine.env.machine(*vm_def)
-            config.master    ||= @master_vm.config.vm.hostname.to_s
+            config.master    ||= ( @master_vm.config.vm.hostname || @master_vm.name ).to_s
           end
         end
       end


### PR DESCRIPTION
Prior to this commit, the master setting of the pe_agent provisioner
would not get set by default if the master_vm did not have a
hostname set on it.

After this commit, the master setting will default to the master_vm
setting if the hostname is not set on the master_vm.