### PR TITLE
Added options that were absent and causing the vagrant up to fail.

### DIFF
--- a/templates/answers/agent-2015.x.txt.erb
+++ b/templates/answers/agent-2015.x.txt.erb
@@ -15,5 +15,8 @@ q_puppet_enterpriseconsole_install=n
 q_puppetagent_install=y
 q_puppetagent_certname=<%= machine_hostname %>
 q_puppetagent_server=<%= @config.master %>
+q_puppetdb_hostname=<%= @config.master %>
+q_database_host=<%= @config.master %>
+q_database_port=5432
 q_skip_master_verification=n
 q_fail_on_unsuccessful_master_lookup=y


### PR DESCRIPTION
Instsaller now needs the q_database_host, q_database_port, and q_puppetdb_hostname set for the installer to work with an answer file.

After making the changes, and then re-running "vagrant up", the systems install without error.