### PR TITLE
Remove temporary passwords from pe.conf template

### DIFF
--- a/templates/answers/master-2016.2.x.conf.erb
+++ b/templates/answers/master-2016.2.x.conf.erb
@@ -7,8 +7,3 @@
 "puppet_enterprise::database_host": "%{::trusted.certname}"
 "puppet_enterprise::pcp_broker_host": "%{::trusted.certname}"
 "puppet_enterprise::mcollective_middleware_hosts": ["%{::trusted.certname}"]
-"puppet_enterprise::puppetdb_database_password": "1ZIhBXimu65wZtXpvMpj"
-"puppet_enterprise::classifier_database_password": "mrwelwaywblIGYjpdHAa"
-"puppet_enterprise::activity_database_password": "HsguT8FOfLgcQ8dpTus9"
-"puppet_enterprise::rbac_database_password": "qfNllIKXaOYRaGt2ZIKU"
-"puppet_enterprise::orchestrator_database_password": "kjhasdASDljhfjhkasd"


### PR DESCRIPTION
With the addition of database cert auth in the puppet_enterprise module,
it should no longer be necessary to provide default passwords for an
install with the new installer.