### PR TITLE
Add Agent type provisioning for Replica and compile masters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -190,6 +190,9 @@ with the global `config.pe_build` settings.
       Currently, agents always receive the `'current'` version installed on the master. Support for setting the version number of agents will be added in a future release. * Options: A version string, `x.y.z[-optional-stuff]`, or the string
       `'current'`.
     * Default: `'current'`.
+  * `agent_type`
+      * Description: The type of agent to provision. This can be set to a agent, compile master, or an HA replica. Some automations are built in to configure the specified agent type on the primary master. Possible values are `'agent'`, `'replica'`, `'compile'`
+      * Default: `'agent'`.
 
 
 Commands

--- a/lib/pe_build/config/pe_agent.rb
+++ b/lib/pe_build/config/pe_agent.rb
@@ -147,6 +147,13 @@ class PEBuild::Config::PEAgent < Vagrant.plugin('2', :config)
           :minimum_version => '2016.5.0',
           :agent_type      => @agent_type
         )
+      elsif @agent_type == 'compile' and PEBuild::Util::VersionString.compare(@version, '2016.1.0') < 0
+        errors << I18n.t(
+          'pebuild.config.pe_agent.errors.agent_type_version_too_old',
+          :version         => @version,
+          :minimum_version => '2016.1.0',
+          :agent_type      => @agent_type
+        )
       end
 
       return

--- a/lib/pe_build/config_builder/1_x/pe_agent.rb
+++ b/lib/pe_build/config_builder/1_x/pe_agent.rb
@@ -30,6 +30,12 @@ class PEBuild::ConfigBuilder::PEAgent < ::ConfigBuilder::Model::Provisioner::Bas
   #   string of the form `x.y.x[-optional-arbitrary-stuff]` or the string
   #   `current`. Defaults to `current`.
   def_model_attribute :version
+  # @!attribute agent_type
+  #   @return [String] The type of agent installation this will be.
+  #   This allows for configuring the agent as an infrastructure component.
+  #   May be either `compile`, `replica, or `agent`.
+  #   Defaults to `agent`.
+  def_model_attribute :agent_type
 
   ::ConfigBuilder::Model::Provisioner.register('pe_agent', self)
 end

--- a/spec/unit/config/pe_agent_spec.rb
+++ b/spec/unit/config/pe_agent_spec.rb
@@ -162,4 +162,38 @@ describe PEBuild::Config::PEAgent do
     end
   end
 
+  describe 'agent_type' do
+    it 'defaults to "agent"' do
+      subject.finalize!
+
+      expect(subject.agent_type).to eq 'agent'
+    end
+
+    it 'accepts "replica" as valid' do
+      subject.agent_type = 'replica'
+      subject.finalize!
+
+      expect(subject.agent_type).to eq 'replica'
+    end
+
+    it 'fails validation if set wrong' do
+      subject.agent_type = 'some-type'
+      subject.finalize!
+
+      errors = subject.validate(machine)
+
+      expect(errors['pe_agent provisioner'].join).to match(/An invalid agent_type of some-type/)
+    end
+
+    it 'fails validation if using an old PE version' do
+      subject.agent_type = 'replica'
+      subject.version = '2016.2.0'
+      subject.finalize!
+
+      errors = subject.validate(machine)
+
+      expect(errors['pe_agent provisioner'].join).to match(/The agent version 2016.2.0 is too old/)
+    end
+  end
+
 end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -95,10 +95,10 @@ en:
         agent_type_invalid: |-
           An invalid agent_type of %{type} has been specified for the agent. Valid types are
           'agent', 'compile', and 'replica'.
-        provisioning_ha_replica: |-
-          Provisioning %{certname} as a replica on %{master}.
-        forgetting_ha_replica: |-
-          Forgetting %{certname} as a replica on %{master}.
+        provisioning_type: |-
+          Provisioning %{certname} as a %{type} on %{master}.
+        cleaning_type: |-
+          Forgetting %{certname} as a %{type} on %{master}.
         code_manager_not_running: |-
           Code Manager is not running on %{master}, cannot provision %{certname} as type %{type}.
         type_cleanup_failed: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -90,6 +90,14 @@ en:
           %{message}
 
           Agent data will have to be removed from %{master} manually.
+        agent_type_provisioned: |-
+          Agent type already provisioned for %{certname} on %{master}. Skipping %{type} provisioning.
+        agent_type_invalid: |-
+          An invalid agent_type of %{type} has been specified for the agent. Valid types are 'agent', 'compile', and 'replica'.
+        provisioning_ha_replica: |-
+          Provisioning %{certname} as a replica on %{master}.
+        forgetting_ha_replica: |-
+          Forgetting %{certname} as a replica on %{master}.
     transfer:
       open_uri:
         download_failed: |-
@@ -144,6 +152,10 @@ en:
           version_too_old: |-
             The agent version %{version} is too old; pe_agent can only provision versions
             newer than %{minimum_version}.
+          agent_type_invalid: |-
+            An invalid agent_type of %{type} has been specified for the agent. Valid types are 'agent', 'compile', and 'replica'.
+          agent_type_version_too_old: |-
+            The agent version %{version} is too old for agent type %{agent_type}. Please use %{minimum_version} or newer.
     cap:
       stage_installer:
         downloading_installer: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -93,11 +93,21 @@ en:
         agent_type_provisioned: |-
           Agent type already provisioned for %{certname} on %{master}. Skipping %{type} provisioning.
         agent_type_invalid: |-
-          An invalid agent_type of %{type} has been specified for the agent. Valid types are 'agent', 'compile', and 'replica'.
+          An invalid agent_type of %{type} has been specified for the agent. Valid types are
+          'agent', 'compile', and 'replica'.
         provisioning_ha_replica: |-
           Provisioning %{certname} as a replica on %{master}.
         forgetting_ha_replica: |-
           Forgetting %{certname} as a replica on %{master}.
+        code_manager_not_running: |-
+          Code Manager is not running on %{master}, cannot provision %{certname} as type %{type}.
+        type_cleanup_failed: |-
+          An error of type %{error_class} occurred while unconfiguring %{type}
+          agent %{certname} from %{master}:
+
+          %{message}
+
+          Any configuration items for %{certname} need to be cleaned up on %{master} manually.
     transfer:
       open_uri:
         download_failed: |-
@@ -153,9 +163,11 @@ en:
             The agent version %{version} is too old; pe_agent can only provision versions
             newer than %{minimum_version}.
           agent_type_invalid: |-
-            An invalid agent_type of %{type} has been specified for the agent. Valid types are 'agent', 'compile', and 'replica'.
+            An invalid agent_type of %{type} has been specified for the agent. Valid types are
+            'agent', 'compile', and 'replica'.
           agent_type_version_too_old: |-
-            The agent version %{version} is too old for agent type %{agent_type}. Please use %{minimum_version} or newer.
+            The agent version %{version} is too old for agent type %{agent_type}.
+            Please use %{minimum_version} or newer.
     cap:
       stage_installer:
         downloading_installer: |-


### PR DESCRIPTION
This PR adds a new provisioner setting to the `pe_agent` provisioner to enable provisioning for different types of agents. The new `agent_type` setting automates some commands on the master to do configuration of the specific type. This PR implements two new types: `compile`, and `replica`. 

The `compile` type is simply a compile master setting, which pins the node to the `PE Master` group in 2016.1+ (2015.x did not have the pin/unpin API) and runs the agent on the CM and then on the master. 

The `replica` setting provisions an HA replica in 2016.5+. It requires code manager to be configured on the master, which can already be done through the `answer_extras` in `pe_bootstrap`. The provisioner will run the agent on the replica, provision the replica on the master, and then enable the replica. Note that this only deploys a `mono` HA topology. 

With the two new types, vagrant can now deploy a full HA environment or a MoM + Compile masters. 

Below are a few additional items to consider before merging this PR.

1. The cleanup of the replica will forget the replica if the master is available. This can add significant time to destroying a full deployment where the master is destroyed after the replica.
2. The compile master code uses the Pin/unpin api, which was not available until 2016.1, so 2015.x is not compatible. 2015.x can have a compile master, but the effort involved in modifying the query does not seem worth it. 
3. Acceptance tests. I did not add any, so let me know if I should.