### PR TITLE
(maint) Allow PE to be installed on Ubuntu 18.04

### DIFF
--- a/lib/pe_build/cap/detect_installer/ubuntu.rb
+++ b/lib/pe_build/cap/detect_installer/ubuntu.rb
@@ -13,7 +13,7 @@ class PEBuild::Cap::DetectInstaller::Ubuntu < PEBuild::Cap::DetectInstaller::POS
   end
 
   def supported_releases
-    %w[10.04 12.04 14.04 15.04 15.10 16.04]
+    %w[10.04 12.04 14.04 15.04 15.10 16.04 18.04]
   end
 
   def arch


### PR DESCRIPTION
Prior to this commit, the `detect_installer` would fail to install PE on
Ubuntu 18.04. This commit adds the capability as the support for 18.04
masters was added in PE 2019.0.x.